### PR TITLE
remove the cypress v5+ native retries suffix from the file name

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -69,9 +69,12 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   const receivedImageBuffer = fs.readFileSync(screenshotPath);
   fs.removeSync(screenshotPath);
 
-  const { dir: screenshotDir, name: snapshotIdentifier } = path.parse(
+  const { dir: screenshotDir, name } = path.parse(
     screenshotPath
   );
+
+  // remove the cypress v5+ native retries suffix from the file name
+  const snapshotIdentifier = name.replace(/ \(attempt [0-9]+\)/, '');
 
   const relativePath = path.relative(screenshotsFolder, screenshotDir);
   const snapshotsDir = customSnapshotsDir


### PR DESCRIPTION
Originally https://github.com/jaredpalmer/cypress-image-snapshot/pull/155